### PR TITLE
made Not enough space for patch a warning

### DIFF
--- a/src/dlditool/dlditool.c
+++ b/src/dlditool/dlditool.c
@@ -406,8 +406,8 @@ int main(int argc, char* argv[])
 		return EXIT_FAILURE;
 	}
 	if (pDH[DO_driverSize] > pAH[DO_allocatedSpace]) {
-		printf ("Not enough space for patch. Available %d bytes, need %d bytes\n", ( 1 << pAH[DO_allocatedSpace]), ( 1 << pDH[DO_driverSize]) );
-		return EXIT_FAILURE;
+		printf ("Warning: Not enough space for patch. Available %d bytes, need %d bytes\n", ( 1 << pAH[DO_allocatedSpace]), ( 1 << pDH[DO_driverSize]) );
+		//return EXIT_FAILURE;
 	}
 
 	memOffset = readAddr (pAH, DO_text_start);


### PR DESCRIPTION
some dldi like ninjapass x9 don't have the correct size in there size descriptor so we need to add a option to ignore the error.
They statically set the size to 32 KiByte nut the dldi itself is smaller.